### PR TITLE
Corrected redirections to domain ontologies

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -40,9 +40,9 @@ RewriteRule ^domain/(domain-)?([^/]+)/inferred/?$ https://emmo-repo.github.io/do
 # Alias:  https://w3id.org/emmo/domain/{DOMAIN}/latest
 # Redirect to master branch
 # {DOMAIN}.ttl file
-RewriteRule ^domain/(domain-)?([^/]+)/$ https://raw.githubusercontent.com/emmo-repo/$1$2/master/$2.ttl [R=303,NE,L]
-RewriteRule ^domain/(domain-)?([^/]+)/latest/?$ https://raw.githubusercontent.com/emmo-repo/$1$2/master/$2.ttl [R=303,NE,L]
-RewriteRule ^domain/(domain-)?([^/]+)/source/?$ https://raw.githubusercontent.com/emmo-repo/$1$2/master/$2.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/latest/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/source/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
 
 
 # Rule 3a: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}
@@ -51,12 +51,12 @@ RewriteRule ^domain/(domain-)?([^/]+)/source/?$ https://raw.githubusercontent.co
 # If the request appears coming from a browser, redirect to the html documentation otherwise redirect to squashed ontology of given version
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/$1$2/versions/$3/$2.html [R=303,NE,L]
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/$1$2/versions/$3/$2.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.html [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.ttl [R=303,NE,L]
 
 # Rule 3b: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/inferred
 # Redirect to GitHub Pages
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/$1$2/versions/$3/$2-inferred.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2-inferred.ttl [R=303,NE,L]
 
 
 # Rule 4: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/source
@@ -127,8 +127,8 @@ RewriteRule ^disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EM
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^([0-9][^/]*)$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
 # Rule 9b: https://w3id.org/emmo/{VERSION}/inferred
 # Redirect to GitHub Pages


### PR DESCRIPTION
Avoid stripping off the `domain-` in the target URL.

Also allow trailing slash when redirecting to EMMO on github pages.